### PR TITLE
Ensure that trailing slash redirects don't include ENV[PORT]

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -13,6 +13,7 @@ http {
   gzip on;
   tcp_nopush on;
   keepalive_timeout 30;
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
 
   server {
     listen <%= ENV["PORT"] %>;


### PR DESCRIPTION
Currently, when nginx does a default file redirect for a url that is missing a trailing `/` it adds the `ENV[PORT]` value to the new url.

Unfortunately, this is the _internal_ container PORT, not the external port the user is browsing on (eg, port 80)

Eg,

`www.mysite.com/folder` -->  `www.mysite.com:61365/folder/`

This PR resolves that problem by adding the `port_in_redirect off;` directive to the nginx.conf