### PR TITLE
Add force https setting to nginx config

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -28,6 +28,11 @@ http {
       auth_basic "Restricted";                                #For Basic Auth
       auth_basic_user_file <%= auth_file %>;  #For Basic Auth
       <% end %>
+      <% if ENV["FORCE_HTTPS"] %>
+      if ($http_x_forwarded_proto = http) {
+        return 301 https://$host$request_uri;
+      }
+      <% end %>
     }
   }
 }


### PR DESCRIPTION
If `FORCE_HTTPS` is set as an environment variable, it redirects all http traffic to https.