### PR TITLE
Remove trailing whitespace from Staticfile 'root:' value

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ cd $build_dir
 # Alternate root location (default is root of project) for html/js/css
 # root: dist/
 if [[ "$(grep root: Staticfile)X" != "X" ]]; then
-  root_dir=$(grep root: Staticfile | sed -e 's/^root: *//')
+  root_dir=$(grep root: Staticfile | sed -e 's/^root: *//;s/\s*$//')
   status "Root folder $root_dir"
 else
   status "Using root folder"


### PR DESCRIPTION
If Staticfile has Windows line endings, $root_dir would also include the trailing carriage return - ie: "foo\r". Trailing whitespace is now removed to avoid this and issues due to trailing spaces. Fixes #23.

Removing just the trailing whitespace seemed safer than trying to match against only non-whitespace characters, since presumably the path could have spaces in it, if on Windows etc.