### PR TITLE
Document custom nginx.conf and mime.types files in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Add a line to your `Staticfile` that begins with `directory:`
 directory: visible
 ```
 
+### Advanced Nginx configuration
+
+You can customise the Nginx configuration further, by adding `nginx.conf` and/or `mime.types` to your root folder.
+
+If the buildpack detects either of these files, they will be used in place of the built-in versions. See the default [nginx.conf](https://github.com/cloudfoundry-incubator/staticfile-buildpack/blob/master/conf/nginx.conf) and [mime.types](https://github.com/cloudfoundry-incubator/staticfile-buildpack/blob/master/conf/nginx.conf) files for inspiration.
+
 Administrator Upload
 ====================
 


### PR DESCRIPTION
I've used https://github.com/cloudfoundry-community/nginx-buildpack#custom-configuration-files as a rough guide, but it seemed more sensible to link to the actual files in the repo than copy-paste the example here. 

Fixes #22.