### PR TITLE
Update mime.types to properly serve JSON files. This addresses #30

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -55,6 +55,7 @@ types {
   application/octet-stream eot;
   application/octet-stream iso img;
   application/octet-stream msi msp msm;
+  application/json json;
   audio/midi mid midi kar;
   audio/mpeg mp3;
   audio/ogg ogg;


### PR DESCRIPTION
Add configuration for JSON files, so that they are served as application/json mime type. Re #30 